### PR TITLE
Adicionado funcionalidade pesquisa de CEP V1 e V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "jest",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
     "check": "prettier --ignore-path .gitignore -c \"**/*.+(js|ts|json)\"",
-    "lint": "eslint .",
-    "prepublishOnly": "npm run build"
+    "lint": "eslint ."
   },
   "author": "Willian Carlos Agostini",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
     "check": "prettier --ignore-path .gitignore -c \"**/*.+(js|ts|json)\"",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepublishOnly": "npm run build"
   },
   "author": "Willian Carlos Agostini",
   "license": "MIT",

--- a/src/routes/cep.ts
+++ b/src/routes/cep.ts
@@ -1,16 +1,10 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.getByV1 = void 0;
-exports.getByV2 = void 0;
-const api_service_1 = require("../service/api.service");
-const format_1 = require("../utils/format");
+import { get } from "../service/api.service";
+import { CepV1, CepV2 } from "../types/cep";
+import { onlyNumbers } from "../utils/format";
+
 const endpointV1 = "/cep/v1/";
 const endpointV2 = "/cep/v2/";
-const getByV1 = (cep) => {
-    return (0, api_service_1.get)(endpointV1 + (0, format_1.onlyNumbers)(cep));
+
+export const getBy = (cep: string, version: string = 'v2') => {
+    (version === "v2") ? get<CepV2>(endpointV2 + onlyNumbers(cep)) : get<CepV1>(endpointV1 + onlyNumbers(cep));
 };
-const getByV2 = (cep) => {
-    return (0, api_service_1.get)(endpointV2 + (0, format_1.onlyNumbers)(cep));
-};
-exports.getByV1 = getByV1;
-exports.getByV2 = getByV2;

--- a/src/routes/cep.ts
+++ b/src/routes/cep.ts
@@ -1,9 +1,16 @@
-import { get } from "../service/api.service";
-import { CepV2 } from "../types/cep";
-import { onlyNumbers } from "../utils/format";
-
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getByV1 = void 0;
+exports.getByV2 = void 0;
+const api_service_1 = require("../service/api.service");
+const format_1 = require("../utils/format");
+const endpointV1 = "/cep/v1/";
 const endpointV2 = "/cep/v2/";
-
-export const getBy = (cep: string) => {
-  return get<CepV2>(endpointV2 + onlyNumbers(cep));
+const getByV1 = (cep) => {
+    return (0, api_service_1.get)(endpointV1 + (0, format_1.onlyNumbers)(cep));
 };
+const getByV2 = (cep) => {
+    return (0, api_service_1.get)(endpointV2 + (0, format_1.onlyNumbers)(cep));
+};
+exports.getByV1 = getByV1;
+exports.getByV2 = getByV2;

--- a/src/routes/cep.ts
+++ b/src/routes/cep.ts
@@ -5,6 +5,8 @@ import { onlyNumbers } from "../utils/format";
 const endpointV1 = "/cep/v1/";
 const endpointV2 = "/cep/v2/";
 
-export const getBy = (cep: string, version: string = 'v2') => {
-    (version === "v2") ? get<CepV2>(endpointV2 + onlyNumbers(cep)) : get<CepV1>(endpointV1 + onlyNumbers(cep));
+export const getBy = (cep: string, version: string = "v2") => {
+  return version === "v2"
+    ? get<CepV2>(endpointV2 + onlyNumbers(cep))
+    : get<CepV1>(endpointV1 + onlyNumbers(cep));
 };


### PR DESCRIPTION
A versão atual está habilitada por padrão apenas a pesquisa para a rota /v2, foi adicionado a rota /v1 na chamada e alterado o nome dos métodos:

BrasilAPI.cep.getBy(cep, **version**)