### PR TITLE
Clean module test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 coverage
+test/module/**/assert.*

--- a/test/module/cjs/index.js
+++ b/test/module/cjs/index.js
@@ -1,2 +1,0 @@
-const assert = require("assert");
-const api = require("brasilapi-js");

--- a/test/module/cjs/package.json
+++ b/test/module/cjs/package.json
@@ -2,10 +2,6 @@
   "name": "cjs-entrypoint-test",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node index.js"
-  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/test/module/cjs/package.json
+++ b/test/module/cjs/package.json
@@ -1,10 +1,5 @@
 {
   "name": "cjs-entrypoint-test",
-  "version": "1.0.0",
-  "description": "",
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   }

--- a/test/module/cts/index.ts
+++ b/test/module/cts/index.ts
@@ -1,2 +1,0 @@
-import assert from "assert";
-import api from "brasilapi-js";

--- a/test/module/cts/package.json
+++ b/test/module/cts/package.json
@@ -1,10 +1,6 @@
 {
   "name": "cts-entrypoint-test",
-  "main": "index.js",
   "type": "commonjs",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"
-  },
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   },

--- a/test/module/cts/package.json
+++ b/test/module/cts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts",
+  "name": "cts-entrypoint-test",
   "main": "index.js",
   "type": "commonjs",
   "scripts": {

--- a/test/module/mjs/index.js
+++ b/test/module/mjs/index.js
@@ -1,2 +1,0 @@
-import assert from "assert";
-import api from "brasilapi-js";

--- a/test/module/mjs/package.json
+++ b/test/module/mjs/package.json
@@ -1,11 +1,6 @@
 {
   "name": "esm-entrypoint-test",
-  "version": "1.0.0",
-  "description": "",
   "type": "module",
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   }

--- a/test/module/mjs/package.json
+++ b/test/module/mjs/package.json
@@ -2,11 +2,7 @@
   "name": "esm-entrypoint-test",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "type": "module",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node index.js"
-  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/test/module/mts/index.ts
+++ b/test/module/mts/index.ts
@@ -1,2 +1,0 @@
-import assert from "assert";
-import api from "brasilapi-js";

--- a/test/module/mts/package.json
+++ b/test/module/mts/package.json
@@ -1,10 +1,6 @@
 {
   "name": "mts-entrypoint-test",
-  "main": "index.js",
   "type": "module",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"
-  },
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   },

--- a/test/module/mts/package.json
+++ b/test/module/mts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts",
+  "name": "mts-entrypoint-test",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/test/module/ts-require/index.ts
+++ b/test/module/ts-require/index.ts
@@ -1,2 +1,0 @@
-const assert = require("assert");
-const api = require("brasilapi-js");

--- a/test/module/ts-require/package.json
+++ b/test/module/ts-require/package.json
@@ -1,9 +1,5 @@
 {
   "name": "ts-require-entrypoint-test",
-  "main": "index.js",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"
-  },
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   },

--- a/test/module/ts-require/package.json
+++ b/test/module/ts-require/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts",
+  "name": "ts-require-entrypoint-test",
   "main": "index.js",
   "scripts": {
     "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"

--- a/test/module/ts/index.ts
+++ b/test/module/ts/index.ts
@@ -1,2 +1,0 @@
-import assert from "assert";
-import api from "brasilapi-js";

--- a/test/module/ts/package.json
+++ b/test/module/ts/package.json
@@ -1,9 +1,5 @@
 {
   "name": "ts-entrypoint-test",
-  "main": "index.js",
-  "scripts": {
-    "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"
-  },
   "dependencies": {
     "brasilapi-js": "file:../../../dist/"
   },

--- a/test/module/ts/package.json
+++ b/test/module/ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts",
+  "name": "ts-entrypoint-test",
   "main": "index.js",
   "scripts": {
     "test": "npm i --no-save --no-package-lock && node --import=tsx index.ts"


### PR DESCRIPTION
## Summary
- remove unused module entrypoints
- ignore generated assert files
- ensure each test module has a unique package name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684760b7090083279cc12ad3eeeb89a3