### PR TITLE
Fix FIPE query parameter separator

### DIFF
--- a/src/routes/fipe/brands.ts
+++ b/src/routes/fipe/brands.ts
@@ -7,7 +7,7 @@ const endpoint = "/fipe/marcas/v1/";
 export const getBy = (typeVehicle: VehicleType, reference_table?: number) => {
   let url = endpoint + typeVehicle;
   if (reference_table) {
-    url += "?tabela_referencia" + reference_table;
+    url += "?tabela_referencia=" + reference_table;
   }
   return get<Brand>(url);
 };

--- a/src/routes/fipe/price.ts
+++ b/src/routes/fipe/price.ts
@@ -6,7 +6,7 @@ const endpoint = "/fipe/preco/v1/";
 export const getBy = (codigoFipe: string, tabela_referencia?: number) => {
   let url = endpoint + codigoFipe;
   if (tabela_referencia) {
-    url += "?tabela_referencia" + tabela_referencia;
+    url += "?tabela_referencia=" + tabela_referencia;
   }
   return get<Price>(url);
 };

--- a/src/routes/fipe/vehicles.ts
+++ b/src/routes/fipe/vehicles.ts
@@ -11,7 +11,7 @@ export const getBy = (
 ) => {
   let url = `${endpoint}/${vehicleType}/${brandCode}`;
   if (tabela_referencia) {
-    url += "?tabela_referencia" + tabela_referencia;
+    url += "?tabela_referencia=" + tabela_referencia;
   }
   return get<VehicleModel[]>(url);
 };


### PR DESCRIPTION
## Summary
- fix FIPE URL query parameters by adding missing `=` sign

## Testing
- `npm test` *(fails: jest-haste-map module collision and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_684762132db48327980fb811437c6833